### PR TITLE
feat: support configuring volume size (k8s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Configuration
 - ``TYPESENSE_DOCKER_IMAGE`` (default: ``"docker.io/typesense/typesense:29.0"``)
 - ``TYPESENSE_BOOTSTRAP_API_KEY`` The initial admin API key to use when bootstrapping the Typesense server and to generate an api key for Open edX (default: auto-generated).
 - ``TYPESENSE_API_KEY`` The API key used by Open edX (default: auto-generated).
+- ``TYPESENSE_VOLUME_SIZE`` The volume size for Typesense data in k8s deployments. See `k8s memory resource units <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory>`_ for available units. (default: ``"5Gi"``)
 
 These values can be modified with ``tutor config save --set PARAM_NAME=VALUE`` commands.
 

--- a/tutor_typesense/patches/k8s-volumes
+++ b/tutor_typesense/patches/k8s-volumes
@@ -11,5 +11,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      # TODO: make this storage size configurable?
-      storage: 5Gi
+      storage: "{{ TYPESENSE_VOLUME_SIZE }}"

--- a/tutor_typesense/plugin.py
+++ b/tutor_typesense/plugin.py
@@ -21,6 +21,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("TYPESENSE_COLLECTION_PREFIX", "tutor_"),
         ("TYPESENSE_PUBLIC_HOST", "typesense.{{ LMS_HOST }}"),
         ("TYPESENSE_DOCKER_IMAGE", "docker.io/typesense/typesense:29.0"),
+        ("TYPESENSE_VOLUME_SIZE", "5Gi"),
     ]
 )
 


### PR DESCRIPTION
## Description

Configuring the volume size is important,
since deployments can vary greatly in size.
This retains the 5Gi default volume size,
but allows configuring it to suit the deployment.

This is only relevant to k8s deployments;
the docker deployments use a directory mounted from the host machine.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9977

## Testing instructions

- install and enable this plugin in a tutor environment
- run `tutor config save`
- verify the pvc for a 5Gi volume is generated for typesense
- set `TYPESENSE_VOLUME_SIZE` to something other than 5Gi in tutor's config.yml
- run `tutor config save` again
- verify the pvc for typesense data now has the size as configured

## Deadline

None